### PR TITLE
Group arrow, datafusion, parquet, & pyo3 together

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,15 +27,11 @@
     {
       "matchPackagePrefixes": [
         "arrow",
-        "parquet"
+        "parquet",
+        "datafusion",
+        "pyo3"
       ],
-      "groupName": "arrow"
-    },
-    {
-      "matchPackagePrefixes": [
-        "datafusion"
-      ],
-      "groupName": "datafusion"
+      "groupName": "arrow + datafusion"
     },
     {
       "matchPackagePrefixes": [

--- a/default.json
+++ b/default.json
@@ -31,7 +31,7 @@
         "datafusion",
         "pyo3"
       ],
-      "groupName": "arrow + datafusion"
+      "groupName": "datafusion and friends"
     },
     {
       "matchPackagePrefixes": [


### PR DESCRIPTION
Since DataFusion version (transitively) pins the other 3