### PR TITLE
Split out PyO3 into a separate group

### DIFF
--- a/default.json
+++ b/default.json
@@ -89,6 +89,12 @@
         "iceberg"
       ],
       "groupName": "iceberg"
+    },
+        {
+      "matchPackagePrefixes": [
+        "pyo3"
+      ],
+      "groupName": "pyo3"
     }
   ]
 }


### PR DESCRIPTION
The way our dependencies generally behave, pyo3 is a pretty serious blocker that moves slowly, so this PR splits it into a separate group.